### PR TITLE
add `loom` in new section `Concurrency Testing`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Turns out, there is an entire subcategory on crates.io [Development tools::Testi
 
 * [mutagem](https://crates.io/crates/mutagen)
 
+### Concurrency Testing
+
+* [loom](https://github.com/tokio-rs/loom)
+
 ### Harnesses/Frameworks
 
 * [rspec](https://crates.io/crates/rspec)  [![Build Status](https://travis-ci.org/rust-rspec/rspec.svg?branch=master)](https://travis-ci.org/rust-rspec/rspec) [![Coverage Status](https://coveralls.io/repos/github/rust-rspec/rspec/badge.svg)](https://coveralls.io/github/rust-rspec/rspec) [![Crates.io](https://img.shields.io/crates/v/rspec.svg?maxAge=2592000)](https://crates.io/crates/rspec) [![Crates.io](https://img.shields.io/crates/l/rspec.svg?maxAge=2592000)](https://github.com/rust-rspec/rspec/blob/master/LICENSE)


### PR DESCRIPTION
Hey there,
this adds a new section `Concurrency Testing` with the crate `loom` in it.
Although `loom` is in it's very early stages of development, I think it is already *awesome*. :smile_cat: 
I deliberately put the section in the middle, because:

1. Concurrency is such a big deal in Rust (it shouldn't be at the bottom)
2. it is near to the other "similar" testing categories like "Property Testing", "Parameterized Testing" and "Mutation Testing"